### PR TITLE
delete should not commit

### DIFF
--- a/src/Plugin/SearchApi/Backend/SearchApiSolrBackend.php
+++ b/src/Plugin/SearchApi/Backend/SearchApiSolrBackend.php
@@ -659,7 +659,6 @@ class SearchApiSolrBackend extends BackendPluginBase {
       $solr_ids[] = $this->createId($index_id, $id);
     }
     $this->getUpdateQuery()->addDeleteByIds($solr_ids);
-    $this->getUpdateQuery()->addCommit(TRUE);
     $this->solr->update($this->getUpdateQuery());
   }
 
@@ -684,7 +683,6 @@ class SearchApiSolrBackend extends BackendPluginBase {
     else {
       $this->getUpdateQuery()->addDeleteQuery('*:*');
     }
-    $this->getUpdateQuery()->addCommit(TRUE);
     $this->solr->update($this->getUpdateQuery());
   }
 


### PR DESCRIPTION
As discussed, delete should not force-commit to prevent timeouts, solr will purge automatically after 2m.

However, I assume this will not work with the tests, as they expect that deletions happen immediately?