### PR TITLE
Add exception handling

### DIFF
--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -653,15 +653,20 @@ class SearchApiSolrBackend extends BackendPluginBase {
    * {@inheritdoc}
    */
   public function deleteItems(IndexInterface $index, array $ids) {
-    $this->connect();
-    $index_id = $this->getIndexId($index->id());
-    $solr_ids = array();
-    foreach ($ids as $id) {
-      $solr_ids[] = $this->createId($index_id, $id);
+    try {
+      $this->connect();
+      $index_id = $this->getIndexId($index->id());
+      $solr_ids = array();
+      foreach ($ids as $id) {
+        $solr_ids[] = $this->createId($index_id, $id);
+      }
+      $this->getUpdateQuery()->addDeleteByIds($solr_ids);
+      $this->getUpdateQuery()->addCommit(TRUE);
+      $this->solr->update($this->getUpdateQuery());
     }
-    $this->getUpdateQuery()->addDeleteByIds($solr_ids);
-    $this->getUpdateQuery()->addCommit(TRUE);
-    $this->solr->update($this->getUpdateQuery());
+    catch (ExceptionInterface $e) {
+      throw new SearchApiException($e->getMessage(), $e->getCode(), $e);
+    }
   }
 
   /**

--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -26,6 +26,7 @@ use Solarium\Client;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Query\Helper;
 use Solarium\QueryType\Select\Query\Query;
+use Solarium\Exception\ExceptionInterface;
 use Solarium\Exception\HttpException;
 use Solarium\QueryType\Select\Result\Result;
 use Solarium\QueryType\Update\Query\Document\Document;


### PR DESCRIPTION
See [#2414347](https://www.drupal.org/node/2414347): when deleting items but Solr isn't running, it seems the Solr backend throws an exception from `deleteItems()` that is not a `SearchApiException` and, therefore, not permitted there. The exception should be caught and re-wrapped instead.

However, upon fixing this I saw that the code currently is never catching any Solarium exceptions (except in `ping()`), so this change is just a start, this needs to happen everywhere we use Solarium methods that can throw exceptions.