### PR TITLE
Update composer.json to be compatible to composer_manger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Offers an implementation of the Search API that uses an Apache Solr server for indexing content.",
   "type": "drupal-module",
   "license": "GPL-2.0+",
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
   "require": {
     "solarium/solarium": "3.2.0"
   }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
   "description": "Offers an implementation of the Search API that uses an Apache Solr server for indexing content.",
   "type": "drupal-module",
   "license": "GPL-2.0+",
-  "minimum-stability": "stable",
   "require": {
     "solarium/solarium": "3.2.0"
   }


### PR DESCRIPTION
In combination with the composer_manager module the minimum-stability set to dev forces the minimum-stability set to dev globally. There's no need for dev here because we use a stable release of solarium.