### PR TITLE
Change Field extras to array_merge.

### DIFF
--- a/src/Utility/Utility.php
+++ b/src/Utility/Utility.php
@@ -49,7 +49,7 @@ class Utility {
       $types = SearchApiUtility::getDataTypeInfo();
 
       // Add our extras for the default search api fields.
-      $types += array(
+      $defaults = array(
         'text' => array(
           'prefix' => 't',
         ),
@@ -78,6 +78,7 @@ class Utility {
           'prefix' => 't',
         ),
       );
+      $types = array_merge_recursive($types, $defaults);
 
       // Extra data type info.
       $extra_types_info = array(


### PR DESCRIPTION
Search API changed the default structure so changed the extras to an array_merge_recursive.

Search API src/Utility.php
```
@@ -80,46 +87,108 @@ class Utility {
   /**
    * Returns the default field types recognized by the Search API.
    *
-   * @return string[]
-   *   An associative array with the default types as keys, mapped to their
-   *   translated display names.
+   * @return string[][]
+   *   A nested associative array with the default types as keys, mapped to
+   *   their translated labels and descriptions.
    */
   public static function getDefaultDataTypes() {
     return array(
-      'text' => \Drupal::translation()->translate('Fulltext'),
-      'string' => \Drupal::translation()->translate('String'),
-      'integer' => \Drupal::translation()->translate('Integer'),
-      'decimal' => \Drupal::translation()->translate('Decimal'),
-      'date' => \Drupal::translation()->translate('Date'),
-      'boolean' => \Drupal::translation()->translate('Boolean'),
+      'text' => array(
+        'label' => t('Fulltext'),
+        'description' => t('A fulltext field'),
+      ),
+      'string' => array(
+        'label' => t('String'),
+        'description' => t('A string field'),
+      ),
+      'integer' => array(
+        'label' => t('Integer'),
+        'description' => t('An integer field'),
+      ),
+      'decimal' => array(
+        'label' => t('Decimal'),
+        'description ' => t('A decimal field'),
+      ),
+      'date' => array(
+        'label' => t('Date'),
+        'description' => t('A date field'),
+      ),
+      'boolean' => array(
+        'label' => t('Boolean'),
+        'description' => t('A boolean field'),
+      ),
     );
   }
```
