### PR TITLE
Update processor configuration for test index

### DIFF
--- a/tests/modules/search_api_test_solr/config/install/search_api.index.solr_search_index.yml
+++ b/tests/modules/search_api_test_solr/config/install/search_api.index.solr_search_index.yml
@@ -21,7 +21,10 @@ options:
       type: string
   processors:
     language:
-      status: true
+      processor_id: language
+      weights:
+        preprocess_index: -50
+      settings: {  }
 datasources:
   - 'entity:entity_test'
 datasource_configs: {  }


### PR DESCRIPTION
Processor config changed, this is causing the tests to fail.

Tests will still fail with this, but they get further. I expect that https://github.com/amateescu/search_api_solr/pull/48 will fix them again.