### PR TITLE
Require solarium 3.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,6 @@
   "type": "drupal-module",
   "license": "GPL-2.0+",
   "require": {
-    "solarium/solarium": "3.2.0"
+    "solarium/solarium": "3.3.0"
   }
 }


### PR DESCRIPTION
Hi, 
Solarium 3.3.0 was released on 12 Nov 2014. it would be good to have it before search_api_solr release :)
i also need this version of solarium to extract file contents with solr in the D8 version of https://www.drupal.org/project/search_api_attachments that i maintain.

Thanks