### PR TITLE
Avoid field names that are not valid java identifiers

### DIFF
--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -982,7 +982,13 @@ class SearchApiSolrBackend extends BackendPluginBase {
         $pref = isset($type_info['prefix']) ? $type_info['prefix'] : '';
         $pref .= ($single_value_name) ? 's' : 'm';
         if (!empty($this->configuration['clean_ids'])) {
-          $name = $pref . '_' . str_replace(':', '$', $key);
+          // Solr doesn't restrict the characters used to build field names. But
+          // using non java identifiers within a field name can cause different
+          // kind of trouble when running querries. Java identifiers are only
+          // consist of letters, digits, '$' and '_'. See
+          // https://issues.apache.org/jira/browse/SOLR-3996
+          // http://docs.oracle.com/cd/E19798-01/821-1841/bnbuk/index.html
+          $name = $pref . '_' . preg_replace('/[^\d\w$_]/', '$', $key);
         }
         else {
           $name = $pref . '_' . $key;


### PR DESCRIPTION
After the discussion in https://www.drupal.org/node/2354271 there was a decision to use a slash ('/') as IndexInterface::DATASOURCE_ID_SEPARATOR. But like the previous separator that leads into different trouble in combination with Solr.
Some parts are described at https://issues.apache.org/jira/browse/SOLR-3996

These problems affect you in different ways when you use field names containing a slash within 'q' or 'fl' or ... , for example if you query the index directly like this:
<code>http://localhost:8983/solr/core1/select?q=*%3A*&fl=tm_entity%24my_entity%2Ffield_text&wt=json
</code>
In this case you get the right amount of documents, but just empty documents.

The solution is to replace all characters which are not valid java identifiers.
