### PR TITLE
PostBigRequest plugin must be loaded before a request is created

### DIFF
--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -853,17 +853,23 @@ class SearchApiSolrBackend extends BackendPluginBase {
       $this->moduleHandler->alter('search_api_solr_query', $solarium_query, $query);
       $this->preQuery($solarium_query, $query);
 
+      // Use the 'postbigrequest' plugin if no specific http method is
+      // configured. The plugin needs to be loaded before the request is
+      // created.
+      if ($this->configuration['http_method'] == 'AUTO') {
+        $this->solr->getPlugin('postbigrequest');
+      }
+
       // Use the manual method of creating a Solarium request so we can control
       // the HTTP method.
       $request = $this->solr->createRequest($solarium_query);
 
-      // Set the HTTP method or use the 'postbigrequest' plugin if no specific
-      // method is configured.
-      if ($this->configuration['http_method'] == 'AUTO') {
-        $this->solr->getPlugin('postbigrequest');
-      }
-      elseif ($this->configuration['http_method'] == 'POST') {
+      // Set the configured HTTP method.
+      if ($this->configuration['http_method'] == 'POST') {
         $request->setMethod(Request::METHOD_POST);
+      }
+      elseif ($this->configuration['http_method'] == 'GET') {
+        $request->setMethod(Request::METHOD_GET);
       }
 
       // Set HTTP Basic Authentication parameter, if login data was set.


### PR DESCRIPTION
The PostBigRequest plugin of solarium is currently not working at all. It needs to be loaded before a request is created because it does its magic within a event listener that acts on the creation of a request!