### PR TITLE
Update solarium version to 3.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,6 @@
   "type": "drupal-module",
   "license": "GPL-2.0+",
   "require": {
-    "solarium/solarium": "3.3.0"
+    "solarium/solarium": "3.4.1"
   }
 }


### PR DESCRIPTION
Solarium 3.4.1 was released on june 14 and seems to be more solr 5 friendly 
https://github.com/solariumphp/solarium/releases