### PR TITLE
Use only alphanumeric or underscore characters for field names. Other…

### DIFF
--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -982,7 +982,13 @@ class SearchApiSolrBackend extends BackendPluginBase {
         $pref = isset($type_info['prefix']) ? $type_info['prefix'] : '';
         $pref .= ($single_value_name) ? 's' : 'm';
         if (!empty($this->configuration['clean_ids'])) {
-          $name = $pref . '_' . str_replace(':', '$', $key);
+          // Solr doesn't restrict the characters used to build field names. But
+          // using non java identifiers within a field name can cause different
+          // kind of trouble when running querries. Java identifiers are only
+          // consist of letters, digits, '$' and '_'. See
+          // https://issues.apache.org/jira/browse/SOLR-3996
+          // http://docs.oracle.com/cd/E19798-01/821-1841/bnbuk/index.html
+          $name = $pref . '_' . preg_replace('/[^\d\w$_]/', '$', $key);
         }
         else {
           $name = $pref . '_' . $key;

--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -983,38 +983,13 @@ class SearchApiSolrBackend extends BackendPluginBase {
         $type_info = SearchApiSolrUtility::getDataTypeInfo($type);
         $pref = isset($type_info['prefix']) ? $type_info['prefix'] : '';
         $pref .= ($single_value_name) ? 's' : 'm';
+        $name = $pref . '_' . $key;
         // @todo A modification of this configuration needs to trigger a
         // deletion of the index and a start of re-index. Or it needs to be
         // avoided at all.
         if (!empty($this->configuration['clean_ids'])) {
-          // Solr doesn't restrict the characters used to build field names. But
-          // using non java identifiers within a field name can cause different
-          // kind of trouble when running querries. Java identifiers are only
-          // consist of letters, digits, '$' and '_'. See
-          // https://issues.apache.org/jira/browse/SOLR-3996
-          // http://docs.oracle.com/cd/E19798-01/821-1841/bnbuk/index.html
-          // For full compatibility the '$' has to be avoided, too. And there're
-          // more restrictions regarding the field name itself. See
-          // https://cwiki.apache.org/confluence/display/solr/Defining+Fields
-          // "Field names should consist of alphanumeric or underscore
-          // characters only and not start with a digit ... Names with both
-          // leading and trailing underscores (e.g. _version_) are reserved."
-          // Field names starting with digits or underscores are already avoided
-          // by our schema.
-          $name = $pref . '_' . preg_replace_callback('/([^\da-zA-Z_])/u',
-            function ($matches) {
-              // Convert non Java identifiers and '$' into byte-wise hexadecimal
-              // values encapsulated by '_'.
-              return '_' . bin2hex($matches[1]) . '_';
-            },
-            // Underscores themselves are converted into their hexadecimal
-            // representation before the replacement above happens.
-            str_replace('_', '_5f_', $key));
+          $name = SearchApiSolrUtility::encodeSolrDynamicFieldName($name);
         }
-        else {
-          $name = $pref . '_' . $key;
-        }
-
         $ret[$key] = $name;
       }
 


### PR DESCRIPTION
… characters will be converted in their hexadecimal representation.