### PR TITLE
Fixed generation of field name mapping.

### DIFF
--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -983,18 +983,11 @@ class SearchApiSolrBackend extends BackendPluginBase {
       );
 
       // Add the names of any fields configured on the index.
-      $fields = $index->getOption('fields', array());
+      $fields = $index->getFields();
       foreach ($fields as $key => $field) {
         // Generate a field name; this corresponds with naming conventions in
         // our schema.xml
-        $type = $field['type'];
-
-        // Use the real type of the field if the server supports this type.
-        if (isset($field['real_type'])) {
-          if ($this->supportsFeature('search_api_data_type_' . $field['real_type'])) {
-            $type = $field['real_type'];
-          }
-        }
+        $type = $field->getType();
 
         $type_info = SearchApiSolrUtility::getDataTypeInfo($type);
         $pref = isset($type_info['prefix']) ? $type_info['prefix'] : '';


### PR DESCRIPTION
When testing (or rather, preparing my DrupalCon demo) I ran into the problem that sometimes the field mapping doesn't return all the index's fields. It seems that not all fields are contained in the field options on the index in some cases? (Actually, that's probably something we should look into in the Search API, but I'd say it can't hurt to fix it in the Solr backend, too. Reading the bare option value is just more brittle than using the proper API function.)
