### PR TITLE
Fix admin solr empty path

### DIFF
--- a/includes/solr_connection.inc
+++ b/includes/solr_connection.inc
@@ -214,7 +214,7 @@ class SearchApiSolrConnection implements SearchApiSolrConnectionInterface {
     );
     $this->options = $options;
 
-    $path = '/' . trim($options['path'], '/') . '/';
+    $path = !empty($options['path']) ? '/' . trim($options['path'], '/') . '/' : '/';
     $this->base_url = $options['scheme'] . '://' . $options['host'] . ':' . $options['port'] . $path;
 
     // Set HTTP Basic Authentication parameter, if login data was set.


### PR DESCRIPTION
In `admin/config/search/search_api/server/ownzones_local/edit` there might be the case **Solr path** needs to be empty. For instance I'm using this module to configure the endpoint to a custom proxy API that then forwards the requests to SOLR. In this case adding a _Solr Path_ will certainly mess up the url to the proxy. Anyhow, since the _Solr path_ field is not required it should be tested for empty value.
